### PR TITLE
docs: add Section 7 — Wallet and Payment Processor Requirements

### DIFF
--- a/protocol-specification.md
+++ b/protocol-specification.md
@@ -242,7 +242,52 @@ Upon receiving a `WWW-Authenticate: L402` challenge:
 4. The client MUST re-issue the original HTTP request with the `Authorization`
    header attached.
 
-## 7. gRPC Protocol Flow
+## 7. Wallet and Payment Processor Requirements
+
+The protocol flows in Sections 6 and 8 specify obligations for the L402 server
+(the resource gatekeeper) and the L402 client (the entity constructing the
+`Authorization` header). The proof chain also depends on a third actor: the
+**wallet or payment processor** that settles the underlying Lightning invoice
+on the client's behalf and surfaces the resulting preimage `r` back to the
+client.
+
+In typical Lightning Network routing, `r` propagates to the client's wallet
+automatically through the HTLC settlement chain; no normative behavior on the
+wallet's part is required. However, when both the payee and payer are hosted
+by the same custodial Lightning service, the service may settle the payment
+internally — crediting the payee's account and debiting the payer's account
+without routing the payment over the Lightning Network. In this scenario, no
+HTLC chain forms, `r` is generated at invoice creation and held by the service
+throughout, and `r` is never propagated to the client by the underlying
+Lightning protocol.
+
+To preserve L402 compatibility regardless of settlement path:
+
+1. A Lightning wallet or payment processor MUST surface the payment preimage
+   `r` to the client for any settled invoice, regardless of whether settlement
+   occurred via HTLC routing or via internal accounting on a single custodial
+   service.
+
+2. A wallet or payment processor that omits `r` from the payment-confirmation
+   response for an internally-settled invoice SHOULD be considered
+   non-compliant with this specification for L402 authentication purposes,
+   since the client cannot construct a valid `Authorization` header without
+   `r`.
+
+3. A wallet or payment processor MUST NOT release the preimage `r` to the
+   client prior to settlement of the corresponding invoice. In standard
+   Lightning routing this is enforced by the HTLC protocol; in
+   internal-settlement implementations it MUST be enforced by the wallet or
+   payment processor's accounting logic. The L402 server's stateless
+   `H == sha256(r)` check (Section 6.1) assumes that possession of `r` by the
+   client implies the invoice has been settled.
+
+These requirements apply equally to the HTTP flow (Section 6) and the gRPC
+flow (Section 8). They impose no requirement on the underlying Lightning
+settlement path; they impose a requirement only on what the wallet or payment
+processor surfaces to the client after settlement.
+
+## 8. gRPC Protocol Flow
 
 gRPC is transmitted over HTTP/2 but uses special trailing headers for
 protocol-specific information. The
@@ -251,7 +296,7 @@ requires a status code of 200 in all responses. As a result, the L402 gRPC
 flow is modified to always return 200 OK at the HTTP level and instead convey
 the payment challenge via gRPC trailing headers.
 
-### 7.1. Server Flow
+### 8.1. Server Flow
 
 The server flow is identical to the HTTP flow (Section 6.1) with the following
 modifications:
@@ -296,7 +341,7 @@ The L402 proxy determines whether a request is gRPC by checking whether the
 `Content-Type` header begins with `application/grpc`. The proxy MUST be HTTP/2
 compatible, since gRPC clients expect an HTTP/2-speaking server.
 
-### 7.2. Client Flow
+### 8.2. Client Flow
 
 The gRPC client flow is identical to the HTTP flow (Section 6.2). Once the
 client has deserialized the proto and extracted the macaroon and invoice, it
@@ -307,7 +352,7 @@ Other gRPC headers and trailers are required as normal; see the
 [gRPC over HTTP2 specification](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md)
 for details.
 
-## 8. Credential Reuse and Revocation
+## 9. Credential Reuse and Revocation
 
 L402 credentials are intended for reuse. A client SHOULD cache and reuse its
 credential until the server rejects it with a new 402 challenge. An L402 can
@@ -324,9 +369,9 @@ Possible revocation conditions include:
 When a credential is revoked, the server issues a fresh 402 challenge and the
 client repeats the payment flow.
 
-## 9. Security Considerations
+## 10. Security Considerations
 
-### 9.1. Transport Security
+### 10.1. Transport Security
 
 L402 credentials are bearer tokens. The macaroon and preimage are transmitted
 as cleartext in HTTP headers and MUST be protected by TLS. Implementations
@@ -336,14 +381,14 @@ TLS 1.3 ([RFC 8446](https://tools.ietf.org/html/rfc8446)) is RECOMMENDED.
 Servers MUST NOT issue L402 challenges over unencrypted HTTP. Clients MUST NOT
 send L402 credentials over unencrypted HTTP.
 
-### 9.2. Credential Interception
+### 10.2. Credential Interception
 
 If a client's L402 is intercepted by an attacker (e.g., via a compromised TLS
 termination point), the attacker can reuse the credential. The L402 proxy would
 not be able to distinguish this usage as illicit, since the credential is a
 bearer token.
 
-### 9.3. Spoofing by Counterfeit Servers
+### 10.3. Spoofing by Counterfeit Servers
 
 L402 is vulnerable to spoofing if a client connects to a malicious server
 (e.g., by mistyping a URL). The malicious server could store the client's L402
@@ -362,21 +407,21 @@ after a network change; a TLS client cert fingerprint requires the client to
 maintain a stable key pair. Deployments SHOULD choose binding predicates
 appropriate to their threat model.
 
-### 9.4. Replay Protection
+### 10.4. Replay Protection
 
 The macaroon itself does not inherently prevent replay. Replay protection comes
 from the caveat and revocation mechanisms: expiry caveats, usage-count tracking,
 and root key deletion all limit the window in which a stolen credential is
 useful.
 
-### 9.5. Amount Verification
+### 10.5. Amount Verification
 
 Clients MUST verify that the invoice amount is reasonable for the requested
 resource before paying. Malicious servers could request arbitrarily large
 payments. Client implementations SHOULD enforce a configurable maximum payment
 threshold.
 
-## 10. Backwards Compatibility
+## 11. Backwards Compatibility
 
 The L402 protocol was formerly known as LSAT. To preserve backwards
 compatibility with deployed clients and servers:
@@ -387,7 +432,7 @@ compatibility with deployed clients and servers:
 - Clients and servers MUST accept both `LSAT` and `L402` in `Authorization`
   headers.
 
-## 11. References
+## 12. References
 
 - [RFC 2119: Key words for use in RFCs](https://tools.ietf.org/html/rfc2119)
 - [RFC 4648: Base Encodings](https://tools.ietf.org/html/rfc4648)


### PR DESCRIPTION
## Summary

Adds a new top-level Section 7, "Wallet and Payment Processor Requirements," to `protocol-specification.md`, addressing a compatibility gap when the underlying Lightning settlement bypasses HTLC routing. Renumbers existing Sections 7–11 to 8–12 to accommodate.

## Motivation

L402's proof-of-payment chain depends on the client obtaining the payment preimage `r` after invoice settlement. In typical Lightning Network routing, `r` propagates back to the client's wallet through the HTLC settlement chain — no normative wallet behavior is required for L402 to work.

However, when both the payee and payer are hosted by the same custodial Lightning service, that service may settle the payment internally — crediting the payee's account and debiting the payer's account without routing the payment over the Lightning Network. In this scenario:

- No HTLC chain forms.
- `r` is generated at invoice creation by the custodian and sits in their database.
- `r` is never propagated to the client through Lightning protocol mechanisms.

If the custodian's payer-facing API does not surface `r` after settlement, the client has no preimage to present in the L402 `Authorization` header, even though the invoice is fully paid. The proof chain is broken: the merchant has the funds, the buyer can't construct a valid L402 token, and the resource access is denied.

This has been observed in production with at least one major custodial Lightning provider whose own developer documentation explicitly describes the optimization (same-currency-region same-app payments executed as internal account transfers, "instant and incurs no routing or on-chain fees") but does not document preimage availability on the payer side. The optimization is intentional and arguably correct from a custodial UX perspective; the L402 incompatibility is collateral damage of a design decision that makes sense in every other respect.

The spec-evolution path is one of several ways to close this gap (others include BOLT12 with blinded paths, which would force real routing by hiding the destination from the payer's wallet, and a vendor opt-in flag forcing real routing per invoice). These approaches are complements, not alternatives. This PR addresses the spec-evolution path: making preimage availability a wallet/processor requirement so the custodian-side fix becomes unambiguous expected behavior rather than a per-integrator request.

## What this PR adds

A new Section 7 "Wallet and Payment Processor Requirements" with three normative bullets:

1. A wallet or payment processor **MUST** surface the payment preimage `r` to the client for any settled invoice, regardless of whether settlement occurred via HTLC routing or via internal accounting on a single custodial service.

2. A wallet or payment processor that omits `r` from the payment-confirmation response for an internally-settled invoice **SHOULD** be considered non-compliant with this specification for L402 authentication purposes.

3. A wallet or payment processor **MUST NOT** release the preimage `r` to the client prior to settlement of the corresponding invoice. In standard Lightning routing this is enforced by the HTLC protocol; in internal-settlement implementations it MUST be enforced by the wallet or payment processor's accounting logic. The L402 server's stateless `H == sha256(r)` check (Section 6.1) assumes that possession of `r` by the client implies the invoice has been settled.

The third bullet is included to make explicit the implicit binding between preimage possession and settlement that the protocol's stateless verification relies on. In the standard HTLC path this is enforced cryptographically by Lightning itself; in the internal-settlement path it has to be enforced by the wallet or payment processor's accounting logic. Without this requirement, a wallet could naively interpret bullet 1 as "release the preimage at invoice creation" and break the L402 server's stateless verification model.

The section explicitly notes that these requirements apply protocol-agnostically — to the HTTP flow (Section 6) and the gRPC flow (Section 8) equally — and that they impose no requirement on the underlying Lightning settlement path. Only what the wallet or payment processor surfaces to the client after settlement is constrained.

## Why a new top-level section

Wallets and payment processors are a third actor in the L402 protocol, alongside the server (Section 6.1) and the client (Section 6.2). Their obligation is protocol-agnostic. Placing the requirement as a subsection under "HTTP Protocol Flow" (Section 6) would imply HTTP-specific scope, which is incorrect. A new top-level section preserves structural parity and makes the wallet/processor obligation discoverable.

If the structural placement is the wrong call, happy to revise — could go as a subsection 6.3 with a one-line cross-reference from the gRPC section.

## What this PR does NOT change

- No change to the L402 challenge format, credential format, or authentication scheme.
- No change to existing server or client obligations.
- No change to the gRPC flow itself — only its section number shifts (7 → 8).
- No requirement on Lightning settlement implementations to alter their routing or settlement behavior. Internal settlement remains a valid optimization; only preimage surfacing and settlement ordering are constrained.

## Renumbering

Sections 7 through 11 of the prior version shift to 8 through 12 in this PR:

- Section 7 (gRPC Protocol Flow) → Section 8
- Section 8 (Credential Reuse and Revocation) → Section 9
- Section 9 (Security Considerations) → Section 10
- Section 10 (Backwards Compatibility) → Section 11
- Section 11 (References) → Section 12

Subsection numbering shifts accordingly (e.g., 9.1 → 10.1). All internal cross-references within the document remain accurate — every existing `Section N.M` reference points to Section 5.x or Section 6.x, both of which are unchanged.

## Acknowledgments

Thanks to Hannah at Lightning Labs DevRel for the pointer to this repo as the right place to land this contribution and for the framing pushback that sharpened the proposed addition. The "implementation issue, not a protocol break" framing is hers; this PR closes the spec gap so that the implementation expectation is normatively explicit.
